### PR TITLE
[round-3] Domain Modeling & Development (Product, Brand, Like, Order)

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandFacade.java
@@ -1,0 +1,18 @@
+package com.loopers.application.brand;
+
+import com.loopers.application.brand.out.BrandInfo;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class BrandFacade {
+    private final BrandService brandService;
+
+    public BrandInfo get(Long brandId) {
+        Brand brand = brandService.get(brandId);
+        return BrandInfo.from(brand);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/out/BrandInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/out/BrandInfo.java
@@ -1,0 +1,17 @@
+package com.loopers.application.brand.out;
+
+import com.loopers.domain.brand.Brand;
+
+public record BrandInfo(
+        Long id,
+        String name,
+        String description
+) {
+    public static BrandInfo from(Brand brand) {
+        return new BrandInfo(
+                brand.getId(),
+                brand.getName(),
+                brand.getDescription()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -1,11 +1,15 @@
 package com.loopers.application.like;
 
 import com.loopers.application.like.in.LikeActionCommand;
+import com.loopers.application.like.out.LikedProductsResult;
 import com.loopers.domain.like.LikeService;
+import com.loopers.domain.like.dto.LikedProductDto;
 import com.loopers.domain.product.ProductService;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -26,5 +30,10 @@ public class LikeFacade {
             throw new CoreException(ErrorType.NOT_FOUND, "상품 ID가 존재하지 않습니다.");
         }
         return likeService.delete(LikeActionCommand.toDomain(command));
+    }
+
+    public Page<LikedProductsResult> getLikedProducts(Long userId, Pageable pageable) {
+        Page<LikedProductDto> likedProducts = likeService.getLikedProducts(userId, pageable);
+        return likedProducts.map(LikedProductsResult::from);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -1,0 +1,17 @@
+package com.loopers.application.like;
+
+
+import com.loopers.application.like.in.LikeCreateCommand;
+import com.loopers.domain.like.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class LikeFacade {
+    private final LikeService likeService;
+
+    public boolean create(LikeCreateCommand command){
+        return likeService.create(LikeCreateCommand.toDomain(command));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -1,7 +1,7 @@
 package com.loopers.application.like;
 
 
-import com.loopers.application.like.in.LikeCreateCommand;
+import com.loopers.application.like.in.LikeActionCommand;
 import com.loopers.domain.like.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,7 +11,11 @@ import org.springframework.stereotype.Component;
 public class LikeFacade {
     private final LikeService likeService;
 
-    public boolean create(LikeCreateCommand command){
-        return likeService.create(LikeCreateCommand.toDomain(command));
+    public boolean create(LikeActionCommand command){
+        return likeService.create(LikeActionCommand.toDomain(command));
+    }
+
+    public boolean delete(LikeActionCommand command) {
+        return likeService.delete(LikeActionCommand.toDomain(command));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeFacade.java
@@ -1,8 +1,10 @@
 package com.loopers.application.like;
 
-
 import com.loopers.application.like.in.LikeActionCommand;
 import com.loopers.domain.like.LikeService;
+import com.loopers.domain.product.ProductService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,12 +12,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class LikeFacade {
     private final LikeService likeService;
+    private final ProductService productService;
 
     public boolean create(LikeActionCommand command){
+        if(productService.existsById(command.refProductId())){
+            throw new CoreException(ErrorType.NOT_FOUND, "상품 ID가 존재하지 않습니다.");
+        }
         return likeService.create(LikeActionCommand.toDomain(command));
     }
 
     public boolean delete(LikeActionCommand command) {
+        if(productService.existsById(command.refProductId())){
+            throw new CoreException(ErrorType.NOT_FOUND, "상품 ID가 존재하지 않습니다.");
+        }
         return likeService.delete(LikeActionCommand.toDomain(command));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/in/LikeActionCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/in/LikeActionCommand.java
@@ -2,11 +2,11 @@ package com.loopers.application.like.in;
 
 import com.loopers.domain.like.Like;
 
-public record LikeCreateCommand(
+public record LikeActionCommand(
         Long refUserId,
         Long refProductId
 ) {
-    public static Like toDomain(LikeCreateCommand command) {
+    public static Like toDomain(LikeActionCommand command) {
         return Like.from(
                 command.refUserId,
                 command.refProductId

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/in/LikeCreateCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/in/LikeCreateCommand.java
@@ -1,0 +1,15 @@
+package com.loopers.application.like.in;
+
+import com.loopers.domain.like.Like;
+
+public record LikeCreateCommand(
+        Long refUserId,
+        Long refProductId
+) {
+    public static Like toDomain(LikeCreateCommand command) {
+        return Like.from(
+                command.refUserId,
+                command.refProductId
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/out/LikedProductsResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/out/LikedProductsResult.java
@@ -1,0 +1,27 @@
+package com.loopers.application.like.out;
+
+import com.loopers.domain.like.dto.LikedProductDto;
+
+import java.math.BigDecimal;
+
+public record LikedProductsResult(
+        Long productId,
+        String productName,
+        BigDecimal originalPrice,
+        BigDecimal sellingPrice,
+        String saleStatus,
+        Long likeId,
+        Boolean liked
+) {
+    public static LikedProductsResult from(LikedProductDto likedProductDto) {
+        return new LikedProductsResult(
+                likedProductDto.productId(),
+                likedProductDto.productName(),
+                likedProductDto.originalPrice(),
+                likedProductDto.sellingPrice(),
+                likedProductDto.saleStatus(),
+                likedProductDto.likeId(),
+                likedProductDto.liked()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderDetailResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderDetailResult.java
@@ -1,0 +1,17 @@
+package com.loopers.application.order;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record OrderDetailResult(
+        Long orderId,
+        String orderStatus,
+        List<OrderItemDetail> items
+) {
+    public record OrderItemDetail(
+            String productName,
+            int quantity,
+            BigDecimal originalPrice,
+            BigDecimal discountedPrice
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,0 +1,76 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.ExternalOrderSender;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.point.vo.Balance;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.stock.Stock;
+import com.loopers.domain.stock.StockRepository;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.domain.user.vo.UserId;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class OrderFacade {
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
+    private final StockRepository stockRepository;
+    private final UserRepository userRepository;
+    private final PointRepository pointRepository;
+    private final ExternalOrderSender externalOrderSender;
+
+    @Transactional
+    public Order placeOrder(String userIdLong, List<OrderItemResult> items, int userPointsToUse) {
+        UserId userId = UserId.from(String.valueOf(userIdLong));
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "사용자가 존재하지 않습니다."));
+
+        for (OrderItemResult item : items) {
+            Stock stock = stockRepository.findByRefProductId(item.productId())
+                    .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "상품 재고가 존재하지 않습니다: " + item.productId()));
+            if (stock.getQuantity() < item.quantity()) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다: " + item.productId());
+            }
+            stockRepository.save(new Stock(stock.getRefProductId(), stock.getQuantity() - item.quantity()));
+        }
+
+        Point point = pointRepository.findByRefUserId(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "포인트 정보가 존재하지 않습니다."));
+        if (point.getBalance().getValue() < userPointsToUse) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "포인트가 부족합니다.");
+        }
+        Balance deducted = Balance.minus(point, userPointsToUse);
+        Point updatedPoint = new Point(userId, deducted);
+        pointRepository.save(updatedPoint);
+
+        List<OrderItem> orderItems = items.stream()
+                .map(req -> {
+                    Product product = productRepository.findById(req.productId())
+                            .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "상품이 존재하지 않습니다: " + req.productId()));
+                    return OrderItem.create(
+                            product.getId(),
+                            req.quantity(),
+                            product.getSellingPrice(),
+                            product.getOriginalPrice());
+                }).toList();
+
+        Order order = Order.create(user.getId(), orderItems);
+        order = orderRepository.save(order); // orderItems 는 cascade로 저장됨
+
+        externalOrderSender.sendOrder(order);
+        return order;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -63,6 +63,7 @@ public class OrderFacade {
                     return OrderItem.create(
                             product.getId(),
                             req.quantity(),
+                            product.getName(),
                             product.getSellingPrice(),
                             product.getOriginalPrice());
                 }).toList();
@@ -88,5 +89,21 @@ public class OrderFacade {
                         )
                 ))
                 .toList();
+    }
+
+    public OrderDetailResult getOrderDetail(Long userId, Long orderId) {
+        Order order = orderRepository.findByIdAndUserId(orderId, userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "주문을 찾을 수 없습니다."));
+
+        List<OrderDetailResult.OrderItemDetail> items = order.getOrderItems().stream()
+                .map(item -> new OrderDetailResult.OrderItemDetail(
+                        item.getProductName(),
+                        item.getQuantity(),
+                        item.getOriginalPrice().getValue(),
+                        item.getSellingPrice().getValue()
+                ))
+                .toList();
+
+        return new OrderDetailResult(order.getId(), order.getOrderStatus().name(), items);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -73,4 +73,20 @@ public class OrderFacade {
         externalOrderSender.sendOrder(order);
         return order;
     }
+
+    public List<OrderSummaryResult> getOrders(Long refUserId) {
+        List<Order> orders = orderRepository.findAllByUserId(refUserId);
+
+        return orders.stream()
+                .flatMap(order -> order.getOrderItems().stream().map(item ->
+                        new OrderSummaryResult(
+                                order.getId(),
+                                order.getOrderStatus().name(),
+                                order.getCreatedAt().toLocalDateTime(),
+                                item.getSellingPrice().getValue(),
+                                item.getProductId()
+                        )
+                ))
+                .toList();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderItemResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderItemResult.java
@@ -1,0 +1,7 @@
+package com.loopers.application.order;
+
+public record OrderItemResult(
+        Long productId,
+        int quantity
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderSummaryResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderSummaryResult.java
@@ -1,0 +1,13 @@
+package com.loopers.application.order;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record OrderSummaryResult(
+        Long orderId,
+        String status,
+        LocalDateTime orderedAt,
+        BigDecimal price,
+        Long productId
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -4,8 +4,6 @@ import com.loopers.application.point.in.PointChargeCommand;
 import com.loopers.application.point.out.PointInfo;
 import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointService;
-import com.loopers.domain.user.vo.UserId;
-import com.loopers.interfaces.api.point.PointV1Dto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -3,6 +3,7 @@ package com.loopers.application.product;
 import com.loopers.application.product.out.ProductDetailInfo;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.like.LikeService;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
 import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
@@ -16,11 +17,13 @@ import org.springframework.stereotype.Component;
 public class ProductFacade {
     private final ProductService productService;
     private final BrandService brandService;
+    private final LikeService likeService;
 
     public ProductDetailInfo getDetail(Long productId) {
         Product product = productService.getDetail(productId);
+        Long likeCount = likeService.countLikeByProductId(productId);
         Brand brand = brandService.get(productId);
-        return ProductDetailInfo.from(product, brand);
+        return ProductDetailInfo.from(product, likeCount, brand);
     }
 
     public Page<ProductWithLikeCountDto> getProducts(Long brandId, Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -1,0 +1,22 @@
+package com.loopers.application.product;
+
+import com.loopers.application.product.out.ProductDetailInfo;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ProductFacade {
+    private final ProductService productService;
+    private final BrandService brandService;
+
+    public ProductDetailInfo getDetail(Long productId) {
+        Product product = productService.getDetail(productId);
+        Brand brand = brandService.get(productId);
+        return ProductDetailInfo.from(product, brand);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductFacade.java
@@ -5,7 +5,10 @@ import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductService;
+import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -18,5 +21,9 @@ public class ProductFacade {
         Product product = productService.getDetail(productId);
         Brand brand = brandService.get(productId);
         return ProductDetailInfo.from(product, brand);
+    }
+
+    public Page<ProductWithLikeCountDto> getProducts(Long brandId, Pageable pageable) {
+        return productService.getProducts(brandId, pageable);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/out/ProductDetailInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/out/ProductDetailInfo.java
@@ -5,8 +5,7 @@ import com.loopers.domain.product.Product;
 
 import java.math.BigDecimal;
 
-// 상품 id, 상품명, 상품설명, 판매상태, 원가, 할인가, 브랜드 id, 브랜드명,
-// 좋아요 수, 좋아요 여부 --> 아직
+// 상품 id, 상품명, 상품설명, 판매상태, 원가, 할인가, 브랜드 id, 브랜드명, 좋아요 수
 public record ProductDetailInfo(
         Long id,
         String name,
@@ -14,17 +13,19 @@ public record ProductDetailInfo(
         String saleStatus,
         BigDecimal originalPrice,
         BigDecimal sellingPrice,
+        Long likeCount,
         Long brandId,
         String brandName
 ) {
-    public static ProductDetailInfo from(Product product, Brand brand) {
+    public static ProductDetailInfo from(Product product, Long likeCount,Brand brand) {
         return new ProductDetailInfo(
                 product.getId(),
                 product.getName(),
                 product.getDescription(),
-                product.getSaleStatus().name(),
+                product.getSaleStatus().toString(),
                 product.getOriginalPrice().getValue(),
                 product.getSellingPrice().getValue(),
+                likeCount,
                 brand.getId(),
                 brand.getName()
         );

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/out/ProductDetailInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/out/ProductDetailInfo.java
@@ -1,0 +1,33 @@
+package com.loopers.application.product.out;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+
+import java.math.BigDecimal;
+
+// 상품 id, 상품명, 상품설명, 판매상태, 원가, 할인가, 브랜드 id, 브랜드명,
+// 좋아요 수, 좋아요 여부 --> 아직
+public record ProductDetailInfo(
+        Long id,
+        String name,
+        String description,
+        String saleStatus,
+        BigDecimal originalPrice,
+        BigDecimal sellingPrice,
+        Long brandId,
+        String brandName
+) {
+    public static ProductDetailInfo from(Product product, Brand brand) {
+        return new ProductDetailInfo(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getSaleStatus().name(),
+                product.getOriginalPrice().getValue(),
+                product.getSellingPrice().getValue(),
+                brand.getId(),
+                brand.getName()
+        );
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -21,4 +21,6 @@ public class UserFacade {
         User user = userService.getByLoginId(loginId);
         return UserInfo.from(user);
     }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
@@ -1,0 +1,35 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "brand")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Brand extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    public static Brand from(String name, String description){
+        validate(name);
+        return new Brand(name,description);
+    }
+
+    public static void validate(String name){
+        if (name == null || name.isBlank()){
+            throw new CoreException(ErrorType.BAD_REQUEST, "브랜드명은 null이거나 빈 문자열일 수 없습니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.brand;
+
+import java.util.Optional;
+
+public interface BrandRepository {
+
+    Optional<Brand> findById(Long brandId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.brand;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class BrandService {
+
+    private final BrandRepository brandRepository;
+
+    public Brand get(Long brandId) {
+        return brandRepository.findById(brandId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "조회 ID로 브랜드가 존재하지 않습니다."));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Table(name = "like")
+@Table(name = "`like`")
 public class Like extends BaseEntity {
 
     @Column(nullable = false)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -1,0 +1,50 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "like")
+public class Like extends BaseEntity {
+
+    @Column(nullable = false)
+    private Long refUserId;
+    @Column(nullable = false)
+    private Long refProductId;
+
+    public static Like from(Long refUserId, Long refProductId) {
+        validateRefUserId(refUserId);
+        validateRefProductId(refProductId);
+        return new Like(
+                refUserId,
+                refProductId
+        );
+    }
+
+    public static void validateRefUserId(Long refUserId) {
+        if (refUserId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "참조 사용자 ID는 null일 수 없습니다.");
+        } else if(refUserId < 0){
+            throw new CoreException(ErrorType.BAD_REQUEST, "참조 사용자 ID는 음수일 수 없습니다.");
+        }
+    }
+
+    public static void validateRefProductId(Long refProductId) {
+        if (refProductId == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "참조 상품 ID는 null일 수 없습니다.");
+        } else if(refProductId < 0){
+            throw new CoreException(ErrorType.BAD_REQUEST, "참조 상품 ID는 음수일 수 없습니다.");
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -3,4 +3,5 @@ package com.loopers.domain.like;
 public interface LikeRepository {
     boolean save(Long refUserId, Long refProductId);
     boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
+    boolean delete(Long refUserId, Long refProductId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -1,7 +1,7 @@
 package com.loopers.domain.like;
 
 public interface LikeRepository {
-    boolean save(Long refUserId, Long refProductId);
+    Like save(Like like);
     boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
     boolean delete(Long refUserId, Long refProductId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -9,4 +9,5 @@ public interface LikeRepository {
     boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
     boolean delete(Long refUserId, Long refProductId);
     Page<LikedProductDto> findLikedProductsByRefUserId(Long refUserId, Pageable pageable);
+    long countLikeByProductId(Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -1,7 +1,12 @@
 package com.loopers.domain.like;
 
+import com.loopers.domain.like.dto.LikedProductDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface LikeRepository {
     Like save(Like like);
     boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
     boolean delete(Long refUserId, Long refProductId);
+    Page<LikedProductDto> findLikedProductsByRefUserId(Long refUserId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.like;
+
+public interface LikeRepository {
+    boolean save(Long refUserId, Long refProductId);
+    boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,6 +1,9 @@
 package com.loopers.domain.like;
 
+import com.loopers.domain.like.dto.LikedProductDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -13,12 +16,17 @@ public class LikeService {
         boolean isExisting = likeRepository.existsByRefUserIdAndRefProductId(like.getRefUserId(), like.getRefProductId());
         if(isExisting) return true;
         Like savedLike = likeRepository.save(like);
-        return savedLike.getId().equals(like.getId());
+
+        return savedLike.getRefUserId().equals(like.getRefUserId());
     }
 
     public boolean delete(Like like) {
         boolean isExisting = likeRepository.existsByRefUserIdAndRefProductId(like.getRefUserId(), like.getRefProductId());
         if(!isExisting) return true;
         return likeRepository.delete(like.getRefUserId(), like.getRefProductId());
+    }
+
+    public Page<LikedProductDto> getLikedProducts(Long refUserId, Pageable pageable) {
+        return likeRepository.findLikedProductsByRefUserId(refUserId, pageable);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -12,7 +12,8 @@ public class LikeService {
         // 상품당 1개의 좋아요만 가능 -> 멱등성 보장
         boolean isExisting = likeRepository.existsByRefUserIdAndRefProductId(like.getRefUserId(), like.getRefProductId());
         if(isExisting) return true;
-        return likeRepository.save(like.getRefUserId(), like.getRefProductId());
+        Like savedLike = likeRepository.save(like);
+        return savedLike.getId().equals(like.getId());
     }
 
     public boolean delete(Like like) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -12,7 +12,12 @@ public class LikeService {
         // 상품당 1개의 좋아요만 가능 -> 멱등성 보장
         boolean isExisting = likeRepository.existsByRefUserIdAndRefProductId(like.getRefUserId(), like.getRefProductId());
         if(isExisting) return true;
-        
-        return likeRepository.save(like);
+        return likeRepository.save(like.getRefUserId(), like.getRefProductId());
+    }
+
+    public boolean delete(Like like) {
+        boolean isExisting = likeRepository.existsByRefUserIdAndRefProductId(like.getRefUserId(), like.getRefProductId());
+        if(!isExisting) return true;
+        return likeRepository.delete(like.getRefUserId(), like.getRefProductId());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.like;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class LikeService {
+    private final LikeRepository likeRepository;
+
+    public boolean create(Like like) {
+        // 상품당 1개의 좋아요만 가능 -> 멱등성 보장
+        boolean isExisting = likeRepository.existsByRefUserIdAndRefProductId(like.getRefUserId(), like.getRefProductId());
+        if(isExisting) return true;
+        
+        return likeRepository.save(like);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -29,4 +29,9 @@ public class LikeService {
     public Page<LikedProductDto> getLikedProducts(Long refUserId, Pageable pageable) {
         return likeRepository.findLikedProductsByRefUserId(refUserId, pageable);
     }
+
+    public long countLikeByProductId(Long productId) {
+        return likeRepository.countLikeByProductId(productId);
+
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/dto/LikedProductDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/dto/LikedProductDto.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.like.dto;
+
+import java.math.BigDecimal;
+
+public record LikedProductDto(
+        Long likeId,
+        Long productId,
+        String productName,
+        BigDecimal originalPrice,
+        BigDecimal sellingPrice,
+        String saleStatus,
+        boolean liked,
+        Long totalLikeCount
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/ExternalOrderSender.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/ExternalOrderSender.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.order;
+
+public interface ExternalOrderSender {
+    void sendOrder(Order order);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "order")
+public class Order extends BaseEntity {
+    @Column(nullable = false)
+    private Long refUserId;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus orderStatus;
+
+    @JoinColumn(name = "order_id")
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    public static Order create(Long refUserId, List<OrderItem> orderItems) {
+        if(orderItems == null || orderItems.isEmpty()) {
+            throw new IllegalArgumentException("주문 아이템은 하나 이상이어야 합니다.");
+        }
+        return new Order(refUserId, OrderStatus.ORDERED, orderItems);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -15,19 +15,25 @@ import lombok.NoArgsConstructor;
 public class OrderItem extends BaseEntity {
     @Column(nullable = false)
     private Long productId;
+
     @Column(nullable = false)
     private int quantity;
+
+    @Column(nullable = false)
+    private String productName;
+
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "selling_price", nullable = false))
     private Money sellingPrice;
+
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "original_price", nullable = false))
     private Money originalPrice;
 
-    public static OrderItem create(Long productId, int quantity, Money sellingPrice, Money originalPrice) {
+    public static OrderItem create(Long productId, int quantity, String productName, Money sellingPrice, Money originalPrice) {
         if(quantity <= 0) {
             throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
         }
-        return new OrderItem(productId, quantity, sellingPrice, originalPrice);
+        return new OrderItem(productId, quantity, productName, sellingPrice, originalPrice);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.product.vo.Money;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "orderItem")
+public class OrderItem extends BaseEntity {
+    @Column(nullable = false)
+    private Long productId;
+    @Column(nullable = false)
+    private int quantity;
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "selling_price", nullable = false))
+    private Money sellingPrice;
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "original_price", nullable = false))
+    private Money originalPrice;
+
+    public static OrderItem create(Long productId, int quantity, Money sellingPrice, Money originalPrice) {
+        if(quantity <= 0) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+        return new OrderItem(productId, quantity, sellingPrice, originalPrice);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.order;
+
+import java.util.Optional;
+
+public interface OrderRepository {
+    Order save(Order order);
+    Optional<Order> findById(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,8 +1,10 @@
 package com.loopers.domain.order;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository {
     Order save(Order order);
     Optional<Order> findById(Long id);
+    List<Order> findAllByUserId(Long refUserId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -7,4 +7,5 @@ public interface OrderRepository {
     Order save(Order order);
     Optional<Order> findById(Long id);
     List<Order> findAllByUserId(Long refUserId);
+    Optional<Order> findByIdAndUserId(Long orderId, Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderStatus.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.order;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+import java.util.Arrays;
+
+public enum OrderStatus {
+    ORDERED,        // 주문 완료 (고객이 주문을 완료한 상태)
+    PAID,           // 결제 완료
+    PACKING,        // 상품 준비 중 (포장, 출고 준비)
+    SHIPPED,        // 배송 중
+    DELIVERED,      // 배송 완료 (고객에게 상품 전달됨)
+    CANCELLED,      // 주문 취소됨
+    RETURN_REQUESTED, // 반품 요청됨
+    RETURNED,       // 반품 완료
+    EXCHANGE_REQUESTED, // 교환 요청됨
+    EXCHANGED,      // 교환 완료
+    FAILED;          // 결제 실패 또는 주문 실패
+
+    public static OrderStatus from(String value) {
+        validate(value);
+        return OrderStatus.valueOf(value);
+    }
+
+    public static void validate(String value){
+        if (value == null || value.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "주문상태는 null이거나 빈 문자열일 수 없습니다.");
+        } else {
+            boolean exists = Arrays.stream(OrderStatus.values())
+                    .anyMatch(g -> g.name().equalsIgnoreCase(value));
+
+            if (!exists) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "주문상태값이 올바르지 않습니다.");
+            }
+        }
+
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 public interface PointRepository {
     Optional<Point> findByRefUserId(UserId refUserId);
     Point save(Point point);
+    void deduct(String userId, long amount);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/vo/Balance.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/vo/Balance.java
@@ -38,4 +38,12 @@ public class Balance {
         validate(amount);
         return new Balance(amount + point.getBalance().getValue());
     }
+
+    public static Balance minus(Point point, long amount) {
+        long current = point.getBalance().getValue();
+        if (current < amount) {
+            throw new IllegalArgumentException("차감할 수 있는 포인트가 부족합니다.");
+        }
+        return new Balance(current - amount);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/vo/Balance.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/vo/Balance.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.point.vo;
 
 import com.loopers.domain.point.Point;
-import com.loopers.domain.user.vo.Email;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Column;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -34,7 +34,6 @@ public class Product extends BaseEntity {
     @AttributeOverride(name = "value", column = @Column(name = "selling_price", nullable = false))
     private Money sellingPrice;
 
-    @Embedded
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private SaleStatus saleStatus;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -43,7 +43,8 @@ public class Product extends BaseEntity {
     private Long refBrandId;
 
     public static Product from(String name, String description, BigDecimal sellingPrice, BigDecimal originalPrice, String saleStatus, Long refBrandId) {
-        validate(name, sellingPrice, originalPrice);
+        validateName(name);
+        validateOriginalPriceAndSellingPrice(originalPrice,sellingPrice);
         return new Product(
                 name,
                 description,
@@ -54,17 +55,15 @@ public class Product extends BaseEntity {
         );
     }
 
-    public static void validate(String name, BigDecimal sellingPrice, BigDecimal originalPrice){
-        // 유효하지 않은 브랜드 ID 인 경우는 application 계층에서 하기
+    public static void validateName(String name){
+        if (name == null || name.isEmpty()){
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품명은 null이거나 빈 문자열일 수 없습니다.");
+        }
+    }
 
-        // 원가보다 할인가가 높은 경우
+    public static void validateOriginalPriceAndSellingPrice(BigDecimal originalPrice, BigDecimal sellingPrice){
         if(originalPrice.compareTo(sellingPrice) < 0){
             throw new CoreException(ErrorType.BAD_REQUEST, "원가보다 할인가가 높을 수 없습니다.");
         }
-        // name이 null 인경우
-        else if (name == null || name.isEmpty()){
-            throw new CoreException(ErrorType.BAD_REQUEST, "상품명은 null이거나 빈 문자열일 수 없습니다.");
-        }
-
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -1,0 +1,70 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.product.vo.Money;
+import com.loopers.domain.product.vo.SaleStatus;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Table(name = "product")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Product extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Embedded
+    @Column(name = "original_price", nullable = false)
+    private Money originalPrice;
+
+    @Embedded
+    @Column(name = "selling_price", nullable = false)
+    private Money sellingPrice;
+
+    @Embedded
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SaleStatus saleStatus;
+
+    @Column(nullable = false)
+    private Long refBrandId;
+
+    public static Product from(String name, String description, BigDecimal sellingPrice, BigDecimal originalPrice, String saleStatus, Long refBrandId) {
+        validate(name, sellingPrice, originalPrice);
+        return new Product(
+                name,
+                description,
+                Money.from(sellingPrice),
+                Money.from(originalPrice),
+                SaleStatus.from(saleStatus),
+                refBrandId
+        );
+    }
+
+    public static void validate(String name, BigDecimal sellingPrice, BigDecimal originalPrice){
+        // 유효하지 않은 브랜드 ID 인 경우는 application 계층에서 하기
+
+        // 원가보다 할인가가 높은 경우
+        if(originalPrice.compareTo(sellingPrice) < 0){
+            throw new CoreException(ErrorType.BAD_REQUEST, "원가보다 할인가가 높을 수 없습니다.");
+        }
+        // name이 null 인경우
+        else if (name == null || name.isEmpty()){
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품명은 null이거나 빈 문자열일 수 없습니다.");
+        }
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -27,11 +27,11 @@ public class Product extends BaseEntity {
     private String description;
 
     @Embedded
-    @Column(name = "original_price", nullable = false)
+    @AttributeOverride(name = "value", column = @Column(name = "original_price", nullable = false))
     private Money originalPrice;
 
     @Embedded
-    @Column(name = "selling_price", nullable = false)
+    @AttributeOverride(name = "value", column = @Column(name = "selling_price", nullable = false))
     private Money sellingPrice;
 
     @Embedded

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.product;
+
+import java.util.Optional;
+
+public interface ProductRepository {
+    Optional<Product> findById(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -5,4 +5,5 @@ import java.util.Optional;
 public interface ProductRepository {
     Optional<Product> findById(Long id);
     boolean existsById(Long id);
+    Product save(Product product);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -4,4 +4,5 @@ import java.util.Optional;
 
 public interface ProductRepository {
     Optional<Product> findById(Long id);
+    boolean existsById(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,9 +1,14 @@
 package com.loopers.domain.product;
 
+import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 
 public interface ProductRepository {
     Optional<Product> findById(Long id);
     boolean existsById(Long id);
     Product save(Product product);
+    Page<ProductWithLikeCountDto> findProductsWithLikeCount(Long brandId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -14,4 +14,8 @@ public class ProductService {
         return productRepository.findById(id)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품 ID가 존재하지 않습니다."));
     }
+
+    public boolean existsById(Long id) {
+        return productRepository.existsById(id);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ProductService {
+    public final ProductRepository productRepository;
+
+    public Product getDetail(Long id) {
+        return productRepository.findById(id)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품 ID가 존재하지 않습니다."));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,8 +1,11 @@
 package com.loopers.domain.product;
 
+import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -17,5 +20,9 @@ public class ProductService {
 
     public boolean existsById(Long id) {
         return productRepository.existsById(id);
+    }
+
+    public Page<ProductWithLikeCountDto> getProducts(Long brandId, Pageable pageable) {
+        return productRepository.findProductsWithLikeCount(brandId, pageable);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Money.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Money.java
@@ -1,9 +1,7 @@
 package com.loopers.domain.product.vo;
 
-import com.loopers.domain.user.vo.Email;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,7 +9,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 @Getter
 @ToString
@@ -28,15 +25,12 @@ public class Money {
     }
 
     public static void validate(BigDecimal value) {
-        if (value == null || value.compareTo(BigDecimal.ZERO) < 0) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "가격은 비어있지 않으며, 음수일 수 없습니다.");
+        if (value == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "가격은 null일 수 없습니다.");
+
+        } else if(value.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "가격은 음수일 수 없습니다.");
         }
     }
 
-    public static BigDecimal calculateDiscountRate(BigDecimal originalPrice, BigDecimal sellingPrice) {
-        BigDecimal discount = originalPrice.subtract(sellingPrice);
-        return discount
-                .divide(originalPrice, 2, RoundingMode.HALF_UP)
-                .multiply(BigDecimal.valueOf(100));
-    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Money.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/Money.java
@@ -1,0 +1,42 @@
+package com.loopers.domain.product.vo;
+
+import com.loopers.domain.user.vo.Email;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Getter
+@ToString
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class Money {
+
+    private BigDecimal value;
+
+    public static Money from(BigDecimal value) {
+        validate(value);
+        return new Money(value);
+    }
+
+    public static void validate(BigDecimal value) {
+        if (value == null || value.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "가격은 비어있지 않으며, 음수일 수 없습니다.");
+        }
+    }
+
+    public static BigDecimal calculateDiscountRate(BigDecimal originalPrice, BigDecimal sellingPrice) {
+        BigDecimal discount = originalPrice.subtract(sellingPrice);
+        return discount
+                .divide(originalPrice, 2, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/SaleStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/SaleStatus.java
@@ -1,0 +1,34 @@
+package com.loopers.domain.product.vo;
+
+import com.loopers.domain.user.vo.Gender;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+import java.util.Arrays;
+
+public enum SaleStatus {
+    ON_SALE,        // 판매 중
+    SOLD_OUT,       // 품절
+    STOP_SELLING,   // 판매 중지 (관리자 수동 중단)
+    PREORDER,       // 예약 판매
+    DISCONTINUED;   // 단종 (더 이상 판매하지 않음)
+
+    public static SaleStatus from(String value) {
+        validate(value);
+        return SaleStatus.valueOf(value);
+    }
+
+    public static void validate(String value){
+        if (value == null || value.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "SaleStatus는 null이거나 빈 문자열일 수 없습니다.");
+        } else {
+            boolean exists = Arrays.stream(SaleStatus.values())
+                    .anyMatch(g -> g.name().equalsIgnoreCase(value));
+
+            if (!exists) {
+                throw new CoreException(ErrorType.BAD_REQUEST, "가능한 SaleStatus가 아닙니다.");
+            }
+        }
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/SaleStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/vo/SaleStatus.java
@@ -1,6 +1,5 @@
 package com.loopers.domain.product.vo;
 
-import com.loopers.domain.user.vo.Gender;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 
@@ -26,7 +25,7 @@ public enum SaleStatus {
                     .anyMatch(g -> g.name().equalsIgnoreCase(value));
 
             if (!exists) {
-                throw new CoreException(ErrorType.BAD_REQUEST, "가능한 SaleStatus가 아닙니다.");
+                throw new CoreException(ErrorType.BAD_REQUEST, "사용 가능한 SaleStatus가 아닙니다.");
             }
         }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
@@ -1,0 +1,43 @@
+package com.loopers.domain.stock;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "stock")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Stock extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long refProductId;
+    @Column(nullable = false)
+    private int quantity;
+
+    public static Stock from(Long refProductId, int quantity) {
+        validateRefProductId(refProductId);
+        validateQuantity(quantity);
+        return new Stock(
+                refProductId,
+                quantity
+        );
+    }
+
+    private static void validateRefProductId(Long refProductId) {
+        if(refProductId == null){
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 ID는 null일 수 없습니다.");
+        }
+    }
+
+    private static void validateQuantity(int quantity) {
+        if(quantity < 0){
+            throw new CoreException(ErrorType.BAD_REQUEST, "재고 수량은 음수일 수 없습니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
@@ -3,7 +3,9 @@ package com.loopers.domain.stock;
 import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,13 +31,15 @@ public class Stock extends BaseEntity {
         );
     }
 
-    private static void validateRefProductId(Long refProductId) {
+    public static void validateRefProductId(Long refProductId) {
         if(refProductId == null){
             throw new CoreException(ErrorType.BAD_REQUEST, "상품 ID는 null일 수 없습니다.");
+        } else if(refProductId < 0){
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 ID는 음수일 수 없습니다.");
         }
     }
 
-    private static void validateQuantity(int quantity) {
+    public static void validateQuantity(int quantity) {
         if(quantity < 0){
             throw new CoreException(ErrorType.BAD_REQUEST, "재고 수량은 음수일 수 없습니다.");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/StockRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.stock;
+
+import java.util.Optional;
+
+public interface StockRepository {
+    Optional<Stock> findByRefProductId(Long refProductId);
+    Stock save(Stock stock);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/vo/UserId.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/vo/UserId.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Embeddable;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 @Getter
@@ -35,5 +36,18 @@ public class UserId {
         } else if (!ID_PATTERN.matcher(value).matches()){
             throw new CoreException(ErrorType.BAD_REQUEST, "ID 가 영문 및 숫자 10자 이내 형식에 맞지 않습니다.");
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserId userId = (UserId) o;
+        return Objects.equals(value, userId.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BrandJpaRepository extends JpaRepository<Brand,Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class BrandRepositoryImpl implements BrandRepository {
+    private final BrandJpaRepository brandJpaRepository;
+
+    @Override
+    public Optional<Brand> findById(Long brandId) {
+        return brandJpaRepository.findById(brandId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeJpaRepository extends JpaRepository<Like,Long> {
+    boolean save(Long refUserId, Long refProductId);
+    boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LikeJpaRepository extends JpaRepository<Like,Long> {
     boolean save(Long refUserId, Long refProductId);
     boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
+
+    boolean deleteByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,9 +1,12 @@
 package com.loopers.infrastructure.like;
 
 import com.loopers.domain.like.Like;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeJpaRepository extends JpaRepository<Like,Long> {
     boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
     boolean deleteByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
+    Page<Like> findAllByRefUserId(Long refUserId, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -4,8 +4,6 @@ import com.loopers.domain.like.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeJpaRepository extends JpaRepository<Like,Long> {
-    boolean save(Long refUserId, Long refProductId);
     boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
-
     boolean deleteByRefUserIdAndRefProductId(Long refUserId, Long refProductId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class LikeRepositoryImpl implements LikeRepository {
+
+    private final LikeJpaRepository likeJpaRepository;
+
+    @Override
+    public boolean save(Long refUserId, Long refProductId) {
+        return likeJpaRepository.save(refUserId, refProductId);
+    }
+
+    @Override
+    public boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId) {
+        return likeJpaRepository.existsByRefUserIdAndRefProductId(refUserId, refProductId);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -2,14 +2,28 @@ package com.loopers.infrastructure.like;
 
 import com.loopers.domain.like.Like;
 import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.like.QLike;
+import com.loopers.domain.like.dto.LikedProductDto;
+import com.loopers.domain.product.QProduct;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
+import static com.querydsl.jpa.JPAExpressions.select;
 @RequiredArgsConstructor
 @Component
 public class LikeRepositoryImpl implements LikeRepository {
 
     private final LikeJpaRepository likeJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Like save(Like like) {
@@ -24,6 +38,45 @@ public class LikeRepositoryImpl implements LikeRepository {
     @Override
     public boolean delete(Long refUserId, Long refProductId) {
         return likeJpaRepository.deleteByRefUserIdAndRefProductId(refUserId, refProductId);
+    }
+
+    @Override
+    public Page<LikedProductDto> findLikedProductsByRefUserId(Long refUserId, Pageable pageable) {
+        QLike like = QLike.like;
+        QProduct product = QProduct.product;
+
+        // 서브쿼리로 상품별 좋아요 수 집계
+        JPQLQuery<Long> likeCountSubQuery = select(like.count())
+                .from(like)
+                .where(like.refProductId.eq(product.id));
+
+        List<LikedProductDto> content = queryFactory
+                .select(Projections.constructor(LikedProductDto.class,
+                        like.id,                        // 좋아요 ID
+                        product.id,                    // 상품 ID
+                        product.name,                  // 상품명
+                        product.originalPrice.value,  // 원가
+                        product.sellingPrice.value,   // 할인가
+                        product.saleStatus.stringValue(), // 판매상태 (enum string)
+                        Expressions.asBoolean(true),  // 좋아요 여부 (조회하는 userId 기준이니까 항상 true)
+                        likeCountSubQuery              // 좋아요 수 (서브쿼리)
+                ))
+                .from(like)
+                .join(product).on(like.refProductId.eq(product.id))
+                .where(like.refUserId.eq(refUserId))
+                .orderBy(like.createdAt.desc()) // 최신순 정렬 (BaseEntity에 createdAt 필드 있다고 가정)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 카운트 쿼리
+        long total = queryFactory
+                .select(like.count())
+                .from(like)
+                .where(like.refUserId.eq(refUserId))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 import static com.querydsl.jpa.JPAExpressions.select;
+
 @RequiredArgsConstructor
 @Component
 public class LikeRepositoryImpl implements LikeRepository {
@@ -77,6 +78,16 @@ public class LikeRepositoryImpl implements LikeRepository {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public long countLikeByProductId(Long productId) {
+        QLike like = QLike.like;
+        return queryFactory
+                .select(like.count())
+                .from(like)
+                .where(like.refProductId.eq(productId))
+                .fetchOne();
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.loopers.infrastructure.like;
 
+import com.loopers.domain.like.Like;
 import com.loopers.domain.like.LikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,8 +12,8 @@ public class LikeRepositoryImpl implements LikeRepository {
     private final LikeJpaRepository likeJpaRepository;
 
     @Override
-    public boolean save(Long refUserId, Long refProductId) {
-        return likeJpaRepository.save(refUserId, refProductId);
+    public Like save(Like like) {
+        return likeJpaRepository.save(like);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -20,4 +20,9 @@ public class LikeRepositoryImpl implements LikeRepository {
         return likeJpaRepository.existsByRefUserIdAndRefProductId(refUserId, refProductId);
     }
 
+    @Override
+    public boolean delete(Long refUserId, Long refProductId) {
+        return likeJpaRepository.deleteByRefUserIdAndRefProductId(refUserId, refProductId);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/ExternalOrderSenderImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/ExternalOrderSenderImpl.java
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.ExternalOrderSender;
+import com.loopers.domain.order.Order;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ExternalOrderSenderImpl implements ExternalOrderSender {
+    private static final Logger log = LoggerFactory.getLogger(ExternalOrderSenderImpl.class);
+
+    @Override
+    public void sendOrder(Order order) {
+        // 실제 외부 시스템 연동은 여기서 구현합니다.
+        // 현재는 Stub 처리 (로그만 출력)
+        log.info("Stub - 외부 시스템으로 주문 전송: orderId = {}", order.getId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderJpaRepository extends JpaRepository<Order,Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -1,7 +1,11 @@
 package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.Order;
+import com.loopers.domain.user.vo.UserId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderJpaRepository extends JpaRepository<Order,Long> {
+    List<Order> findByRefUserId(Long refUserId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -1,11 +1,12 @@
 package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.Order;
-import com.loopers.domain.user.vo.UserId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderJpaRepository extends JpaRepository<Order,Long> {
     List<Order> findByRefUserId(Long refUserId);
+    Optional<Order> findByIdAndRefUserId(Long id, Long refUserId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderRepository;
-import com.loopers.domain.user.vo.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,5 +26,10 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public List<Order> findAllByUserId(Long refUserId) {
         return jpaOrderRepository.findByRefUserId(refUserId);
+    }
+
+    @Override
+    public Optional<Order> findByIdAndUserId(Long orderId, Long userId) {
+        return jpaOrderRepository.findByIdAndRefUserId(orderId, userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -2,9 +2,11 @@ package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.user.vo.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -20,5 +22,10 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public Optional<Order> findById(Long id) {
         return jpaOrderRepository.findById(id);
+    }
+
+    @Override
+    public List<Order> findAllByUserId(Long refUserId) {
+        return jpaOrderRepository.findByRefUserId(refUserId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class OrderRepositoryImpl implements OrderRepository {
+    private final OrderJpaRepository jpaOrderRepository;
+
+    @Override
+    public Order save(Order order) {
+        return jpaOrderRepository.save(order);
+    }
+
+    @Override
+    public Optional<Order> findById(Long id) {
+        return jpaOrderRepository.findById(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductJpaRepository extends JpaRepository<Product,Long> {
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,12 +1,8 @@
 package com.loopers.infrastructure.product;
 
-import com.loopers.domain.point.Point;
 import com.loopers.domain.product.Product;
-import com.loopers.domain.user.vo.UserId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ProductJpaRepository extends JpaRepository<Product,Long> {
-    Optional<Point> findByRefUserId(UserId refUserId);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,8 +1,12 @@
 package com.loopers.infrastructure.product;
 
+import com.loopers.domain.point.Point;
 import com.loopers.domain.product.Product;
+import com.loopers.domain.user.vo.UserId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductJpaRepository extends JpaRepository<Product,Long> {
+import java.util.Optional;
 
+public interface ProductJpaRepository extends JpaRepository<Product,Long> {
+    Optional<Point> findByRefUserId(UserId refUserId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final ProductJpaRepository productJpaRepository;
+
+    @Override
+    public Optional<Product> findById(Long id) {
+        return productJpaRepository.findById(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -17,4 +17,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public Optional<Product> findById(Long id) {
         return productJpaRepository.findById(id);
     }
+
+    @Override
+    public boolean existsById(Long id) {
+        return productJpaRepository.existsById(id);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -1,10 +1,20 @@
 package com.loopers.infrastructure.product;
 
+import com.loopers.domain.brand.QBrand;
+import com.loopers.domain.like.QLike;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.QProduct;
+import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -12,6 +22,7 @@ import java.util.Optional;
 public class ProductRepositoryImpl implements ProductRepository {
 
     private final ProductJpaRepository productJpaRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Optional<Product> findById(Long id) {
@@ -26,5 +37,50 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public Product save(Product product) {
         return productJpaRepository.save(product);
+    }
+
+    @Override
+    public Page<ProductWithLikeCountDto> findProductsWithLikeCount(Long brandId, Pageable pageable) {
+        QProduct product = QProduct.product;
+        QBrand brand = QBrand.brand;
+        QLike like = QLike.like;
+
+        // 좋아요 수 서브쿼리 (상품별 좋아요 수)
+        var likeCountSubQuery = queryFactory
+                .select(like.refProductId, like.count())
+                .from(like)
+                .groupBy(like.refProductId);
+
+        // 메인 쿼리
+        List<ProductWithLikeCountDto> content = queryFactory
+                .select(Projections.constructor(ProductWithLikeCountDto.class,
+                        product.id,
+                        product.name,
+                        product.originalPrice.value,
+                        product.sellingPrice.value,
+                        product.saleStatus,
+                        brand.id,
+                        brand.name,
+                        // 좋아요 수, 없으면 0으로 처리
+                        like.count().coalesce(0L)
+                ))
+                .from(product)
+                .leftJoin(brand).on(product.refBrandId.eq(brand.id))
+                .leftJoin(like).on(like.refProductId.eq(product.id))
+                .where(brandId != null ? product.refBrandId.eq(brandId) : null)
+                .groupBy(product.id, brand.id)
+                .orderBy(product.createdAt.desc())  // 최신순 정렬
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 카운트 쿼리 (브랜드 필터 조건 적용)
+        long total = queryFactory
+                .select(product.count())
+                .from(product)
+                .where(brandId != null ? product.refBrandId.eq(brandId) : null)
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> total);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -22,4 +22,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public boolean existsById(Long id) {
         return productJpaRepository.existsById(id);
     }
+
+    @Override
+    public Product save(Product product) {
+        return productJpaRepository.save(product);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.stock;
+
+import com.loopers.domain.stock.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StockJpaRepository extends JpaRepository<Stock,Long> {
+    Optional<Stock> findByRefProductId(Long refProductId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.stock;
+
+import com.loopers.domain.stock.Stock;
+import com.loopers.domain.stock.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class StockRepositoryImpl implements StockRepository {
+
+    private final StockJpaRepository jpaStockRepository;
+
+    @Override
+    public Optional<Stock> findByRefProductId(Long refProductId) {
+        return jpaStockRepository.findByRefProductId(refProductId);
+    }
+
+    @Override
+    public Stock save(Stock stock) {
+        return jpaStockRepository.save(stock);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.loopers.infrastructure.user;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.domain.user.vo.UserId;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -3,8 +3,6 @@ package com.loopers.infrastructure.user;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.domain.user.vo.UserId;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Controller.java
@@ -1,0 +1,27 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.application.brand.BrandFacade;
+import com.loopers.application.brand.out.BrandInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/brands")
+public class BrandV1Controller {
+
+    private final BrandFacade brandFacade;
+
+    @GetMapping("/{brandId}")
+    public ResponseEntity<BrandV1Dto.BrandInfoResponse> get(@PathVariable Long brandId){
+        BrandInfo brandInfo = brandFacade.get(brandId);
+        BrandV1Dto.BrandInfoResponse response = BrandV1Dto.BrandInfoResponse.from(brandInfo);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Dto.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.brand;
+
+import com.loopers.application.brand.out.BrandInfo;
+
+public class BrandV1Dto {
+    public record BrandInfoResponse(
+            Long id,
+            String name,
+            String description
+    ) {
+        public static BrandInfoResponse from(BrandInfo brandInfo) {
+            return new BrandInfoResponse(
+                    brandInfo.id(),
+                    brandInfo.name(),
+                    brandInfo.description()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.application.like.LikeFacade;
+import com.loopers.application.like.in.LikeCreateCommand;
+import com.loopers.support.auth.AuthenticatedUserIdProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/like")
+public class LikeV1Controller {
+    private final LikeFacade likeFacade;
+
+    @PostMapping("/products")
+    public ResponseEntity<LikeV1Dto.LikeCreateResponse> create(@RequestHeader HttpServletRequest headers,
+                                                              @RequestBody LikeV1Dto.LikeCreateRequest request)
+    {
+        Long userId = AuthenticatedUserIdProvider.getUserId(headers);
+        LikeCreateCommand command = LikeV1Dto.LikeCreateRequest.toCommand(request, userId);
+        boolean isLiked = likeFacade.create(command);
+        LikeV1Dto.LikeCreateResponse response = LikeV1Dto.LikeCreateResponse.from(command, isLiked);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.like;
 
 import com.loopers.application.like.LikeFacade;
-import com.loopers.application.like.in.LikeCreateCommand;
+import com.loopers.application.like.in.LikeActionCommand;
 import com.loopers.support.auth.AuthenticatedUserIdProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +16,24 @@ public class LikeV1Controller {
     private final LikeFacade likeFacade;
 
     @PostMapping("/products")
-    public ResponseEntity<LikeV1Dto.LikeCreateResponse> create(@RequestHeader HttpServletRequest headers,
-                                                              @RequestBody LikeV1Dto.LikeCreateRequest request)
+    public ResponseEntity<LikeV1Dto.LikeActionResponse> create(@RequestHeader HttpServletRequest headers,
+                                                               @RequestBody LikeV1Dto.LikeActionRequest request)
     {
         Long userId = AuthenticatedUserIdProvider.getUserId(headers);
-        LikeCreateCommand command = LikeV1Dto.LikeCreateRequest.toCommand(request, userId);
+        LikeActionCommand command = LikeV1Dto.LikeActionRequest.toCommand(request, userId);
         boolean isLiked = likeFacade.create(command);
-        LikeV1Dto.LikeCreateResponse response = LikeV1Dto.LikeCreateResponse.from(command, isLiked);
+        LikeV1Dto.LikeActionResponse response = LikeV1Dto.LikeActionResponse.from(command, isLiked);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping("/products")
+    public ResponseEntity<LikeV1Dto.LikeActionResponse> delete(@RequestHeader HttpServletRequest headers,
+                                                               @RequestBody LikeV1Dto.LikeActionRequest request)
+    {
+        Long userId = AuthenticatedUserIdProvider.getUserId(headers);
+        LikeActionCommand command = LikeV1Dto.LikeActionRequest.toCommand(request, userId);
+        boolean isLiked = likeFacade.delete(command);
+        LikeV1Dto.LikeActionResponse response = LikeV1Dto.LikeActionResponse.from(command, isLiked);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Controller.java
@@ -2,9 +2,14 @@ package com.loopers.interfaces.api.like;
 
 import com.loopers.application.like.LikeFacade;
 import com.loopers.application.like.in.LikeActionCommand;
+import com.loopers.application.like.out.LikedProductsResult;
 import com.loopers.support.auth.AuthenticatedUserIdProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,9 +21,9 @@ public class LikeV1Controller {
     private final LikeFacade likeFacade;
 
     @PostMapping("/products")
-    public ResponseEntity<LikeV1Dto.LikeActionResponse> create(@RequestHeader HttpServletRequest headers,
-                                                               @RequestBody LikeV1Dto.LikeActionRequest request)
-    {
+    public ResponseEntity<LikeV1Dto.LikeActionResponse> create(
+            HttpServletRequest headers,
+            @RequestBody LikeV1Dto.LikeActionRequest request){
         Long userId = AuthenticatedUserIdProvider.getUserId(headers);
         LikeActionCommand command = LikeV1Dto.LikeActionRequest.toCommand(request, userId);
         boolean isLiked = likeFacade.create(command);
@@ -27,13 +32,24 @@ public class LikeV1Controller {
     }
 
     @DeleteMapping("/products")
-    public ResponseEntity<LikeV1Dto.LikeActionResponse> delete(@RequestHeader HttpServletRequest headers,
-                                                               @RequestBody LikeV1Dto.LikeActionRequest request)
-    {
+    public ResponseEntity<LikeV1Dto.LikeActionResponse> delete(
+            HttpServletRequest headers,
+            @RequestBody LikeV1Dto.LikeActionRequest request){
         Long userId = AuthenticatedUserIdProvider.getUserId(headers);
         LikeActionCommand command = LikeV1Dto.LikeActionRequest.toCommand(request, userId);
         boolean isLiked = likeFacade.delete(command);
         LikeV1Dto.LikeActionResponse response = LikeV1Dto.LikeActionResponse.from(command, isLiked);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/products")
+    public ResponseEntity<Page<LikeV1Dto.LikedProductResponse>> getLikedProducts(
+            HttpServletRequest headers,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Long refUserId = AuthenticatedUserIdProvider.getUserId(headers);
+
+        Page<LikedProductsResult> result = likeFacade.getLikedProducts(refUserId, pageable);
+        Page<LikeV1Dto.LikedProductResponse> response = result.map(LikeV1Dto.LikedProductResponse::from);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -1,6 +1,9 @@
 package com.loopers.interfaces.api.like;
 
 import com.loopers.application.like.in.LikeActionCommand;
+import com.loopers.application.like.out.LikedProductsResult;
+
+import java.math.BigDecimal;
 
 public class LikeV1Dto {
     public record LikeActionRequest(
@@ -22,6 +25,28 @@ public class LikeV1Dto {
             return new LikeActionResponse(
                     command.refProductId(),
                     isLiked
+            );
+        }
+    }
+
+    public record LikedProductResponse(
+            Long productId,
+            String productName,
+            BigDecimal originalPrice,
+            BigDecimal sellingPrice,
+            String saleStatus,
+            Long likeId,
+            Boolean liked
+    ) {
+        public static LikedProductResponse from(LikedProductsResult result){
+            return new LikedProductResponse(
+                    result.productId(),
+                    result.productName(),
+                    result.originalPrice(),
+                    result.sellingPrice(),
+                    result.saleStatus(),
+                    result.likeId(),
+                    result.liked()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -1,25 +1,25 @@
 package com.loopers.interfaces.api.like;
 
-import com.loopers.application.like.in.LikeCreateCommand;
+import com.loopers.application.like.in.LikeActionCommand;
 
 public class LikeV1Dto {
-    public record LikeCreateRequest(
+    public record LikeActionRequest(
             Long refProductId
     ){
-        public static LikeCreateCommand toCommand(LikeCreateRequest request, Long refUserId) {
-            return new LikeCreateCommand(
+        public static LikeActionCommand toCommand(LikeActionRequest request, Long refUserId) {
+            return new LikeActionCommand(
                     request.refProductId,
                     refUserId
             );
         }
     }
 
-    public record LikeCreateResponse(
+    public record LikeActionResponse(
             Long refProductId,
             boolean isLiked
     ) {
-        public static LikeCreateResponse from(LikeCreateCommand command, boolean isLiked) {
-            return new LikeCreateResponse(
+        public static LikeActionResponse from(LikeActionCommand command, boolean isLiked) {
+            return new LikeActionResponse(
                     command.refProductId(),
                     isLiked
             );

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.application.like.in.LikeCreateCommand;
+
+public class LikeV1Dto {
+    public record LikeCreateRequest(
+            Long refProductId
+    ){
+        public static LikeCreateCommand toCommand(LikeCreateRequest request, Long refUserId) {
+            return new LikeCreateCommand(
+                    request.refProductId,
+                    refUserId
+            );
+        }
+    }
+
+    public record LikeCreateResponse(
+            Long refProductId,
+            boolean isLiked
+    ) {
+        public static LikeCreateResponse from(LikeCreateCommand command, boolean isLiked) {
+            return new LikeCreateResponse(
+                    command.refProductId(),
+                    isLiked
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -2,7 +2,6 @@ package com.loopers.interfaces.api.point;
 
 import com.loopers.application.point.in.PointChargeCommand;
 import com.loopers.application.point.out.PointInfo;
-import com.loopers.interfaces.api.user.UserV1Dto;
 
 public class PointV1Dto {
     public record PointChargeRequest(

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -1,0 +1,27 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.ProductFacade;
+import com.loopers.application.product.out.ProductDetailInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+public class ProductV1Controller {
+    private final ProductFacade productFacade;
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductV1Dto.ProductInfoResponse> get(@PathVariable Long productId, @RequestHeader Map<String, String> headers){
+        if( null == headers.get("X-USER-ID") && "".equals(headers.get("X-USER-ID"))){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+        ProductDetailInfo productDetailInfo = productFacade.getDetail(productId);
+        ProductV1Dto.ProductInfoResponse response = ProductV1Dto.ProductInfoResponse.from(productDetailInfo);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -4,8 +4,7 @@ import com.loopers.application.product.out.ProductDetailInfo;
 
 public class ProductV1Dto {
     public record ProductInfoResponse(ProductDetailInfo productDetailInfo
-            // 상품 id, 상품명, 상품설명, 판매상태, 원가, 할인가, 브랜드 id, 브랜드명,
-                                      // 좋아요 수, 좋아요 여부 -> 아직
+            // 상품 id, 상품명, 상품설명, 판매상태, 원가, 할인가, 브랜드 id, 브랜드명, 좋아요 수
     ){
         public static ProductInfoResponse from(ProductDetailInfo productDetailInfo){
             return new ProductInfoResponse(productDetailInfo);

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -1,0 +1,14 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.application.product.out.ProductDetailInfo;
+
+public class ProductV1Dto {
+    public record ProductInfoResponse(ProductDetailInfo productDetailInfo
+            // 상품 id, 상품명, 상품설명, 판매상태, 원가, 할인가, 브랜드 id, 브랜드명,
+                                      // 좋아요 수, 좋아요 여부 -> 아직
+    ){
+        public static ProductInfoResponse from(ProductDetailInfo productDetailInfo){
+            return new ProductInfoResponse(productDetailInfo);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductWithLikeCountDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductWithLikeCountDto.java
@@ -1,0 +1,20 @@
+package com.loopers.interfaces.api.product;
+
+import com.loopers.domain.product.vo.SaleStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class ProductWithLikeCountDto {
+    private Long productId;
+    private String productName;
+    private BigDecimal originalPrice;
+    private BigDecimal sellingPrice;
+    private SaleStatus saleStatus;
+    private Long brandId;
+    private String brandName;
+    private Long likeCount;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/auth/AuthenticatedUserIdProvider.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/auth/AuthenticatedUserIdProvider.java
@@ -1,0 +1,18 @@
+package com.loopers.support.auth;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class AuthenticatedUserIdProvider {
+    private static final String USER_ID_HEADER = "X-USER-ID";
+
+    public static Long getUserId(HttpServletRequest request) {
+        String userId = request.getHeader(USER_ID_HEADER);
+        if (userId == null || userId.isBlank()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "X-USER-ID 헤더가 존재하지 않습니다.");
+        }
+
+        return Long.valueOf(userId);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderFacadeTest.java
@@ -1,0 +1,100 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.ExternalOrderSender;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.vo.Money;
+import com.loopers.domain.stock.Stock;
+import com.loopers.domain.stock.StockRepository;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.domain.user.vo.UserId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class OrderFacadeTest {
+    @InjectMocks
+    private OrderFacade orderFacade;
+
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private StockRepository stockRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PointRepository pointRepository;
+    @Mock
+    private ExternalOrderSender externalOrderSender;
+
+    @DisplayName("상품을 여러개 한꺼번에 주문할 수 있다.")
+    @Test
+    void placeOrder_shouldSucceed_whenValidInput() {
+        // given
+        Long userId = 1L;
+        UserId userIdVo = UserId.from("test123");
+        List<OrderItemResult> items = List.of(
+                new OrderItemResult(10L, 2),
+                new OrderItemResult(11L, 1),
+                new OrderItemResult(12L, 1)
+        );
+        int pointsToUse = 1000;
+
+        Product product1 = Product.from("상품명","설명1",BigDecimal.valueOf(5000L),BigDecimal.valueOf(9000L),"ON_SALE", 1L);
+        Product product2 = Product.from("상품명","설명1",BigDecimal.valueOf(5000L),BigDecimal.valueOf(9000L),"ON_SALE", 1L);
+        Product product3 = Product.from("상품명","설명1",BigDecimal.valueOf(5000L),BigDecimal.valueOf(9000L),"ON_SALE", 1L);
+
+        Stock stock1 = Stock.from(10L, 10);
+        Stock stock2 = Stock.from(11L, 10);
+        Stock stock3 = Stock.from(12L, 10);
+
+        User user = User.from("test123", "test@naver.com", "2000-12-28", "F");
+        Point point = Point.from("test123", 30000L);
+        Order dummyOrder = Order.create(userId, List.of(
+                OrderItem.create(10L, 2, Money.from(BigDecimal.valueOf(3000L)), Money.from(BigDecimal.valueOf(3000L))),
+                OrderItem.create(11L, 3, Money.from(BigDecimal.valueOf(3000L)), Money.from(BigDecimal.valueOf(3000L))),
+                OrderItem.create(12L, 1, Money.from(BigDecimal.valueOf(3000L)), Money.from(BigDecimal.valueOf(3000L)))
+        ));
+
+        // when
+        Mockito.when(userRepository.findByUserId(userIdVo)).thenReturn(Optional.of(user));
+
+        Mockito.when(stockRepository.findByRefProductId(10L)).thenReturn(Optional.of(stock1));
+        Mockito.when(stockRepository.findByRefProductId(11L)).thenReturn(Optional.of(stock2));
+        Mockito.when(stockRepository.findByRefProductId(12L)).thenReturn(Optional.of(stock3));
+
+        Mockito.when(productRepository.findById(10L)).thenReturn(Optional.of(product1));
+        Mockito.when(productRepository.findById(11L)).thenReturn(Optional.of(product2));
+        Mockito.when(productRepository.findById(12L)).thenReturn(Optional.of(product3));
+
+        Mockito.when(pointRepository.findByRefUserId(userIdVo)).thenReturn(Optional.of(point));
+        Mockito.when(orderRepository.save(Mockito.any(Order.class))).thenReturn(dummyOrder);
+
+        Order order = orderFacade.placeOrder(userIdVo.getValue(), items, pointsToUse);
+
+        // then
+        Assertions.assertNotNull(order);
+        Mockito.verify(stockRepository, Mockito.times(3)).save(Mockito.any(Stock.class));
+        Mockito.verify(pointRepository).save(Mockito.any(Point.class));
+        Mockito.verify(orderRepository).save(Mockito.any(Order.class));
+        Mockito.verify(externalOrderSender).sendOrder(Mockito.any(Order.class));
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductFacadeTest.java
@@ -1,0 +1,61 @@
+package com.loopers.application.product;
+
+import com.loopers.application.product.out.ProductDetailInfo;
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class ProductFacadeTest {
+    private ProductService productService;
+    private BrandService brandService;
+    private LikeService likeService;
+    private ProductFacade productFacade;
+
+    @BeforeEach
+    void setUp() {
+        productService = mock(ProductService.class);
+        brandService = mock(BrandService.class);
+        likeService = mock(LikeService.class);
+        productFacade = new ProductFacade(productService, brandService, likeService);
+    }
+
+    @Test
+    @DisplayName("상품 상세 조회 성공 - 상품, 좋아요 수, 브랜드 정보 반환")
+    void getDetail_success() {
+        // given
+        Long productId = 1L;
+        Product product = Product.from("상품1","설명", BigDecimal.valueOf(20000L), BigDecimal.valueOf(30000L),"ON_SALE", 1L);
+        Brand brand = mock(Brand.class);
+        Long likeCount = 42L;
+
+        when(productService.getDetail(productId)).thenReturn(product);
+        when(brandService.get(productId)).thenReturn(brand);
+        when(likeService.countLikeByProductId(productId)).thenReturn(likeCount);
+
+        // when
+        ProductDetailInfo result = productFacade.getDetail(productId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.likeCount()).isEqualTo(likeCount);
+        assertThat(result.id()).isEqualTo(product.getId());
+        assertThat(result.brandId()).isEqualTo(brand.getId());
+
+        verify(productService).getDetail(productId);
+        verify(brandService).get(productId);
+        verify(likeService).countLikeByProductId(productId);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandTest.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.stock.Stock;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BrandTest {
+
+    @DisplayName("브랜드명은 null이거나 빈 문자열일 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateBrand_whenBrandNameIsNullOrBlank() {
+        // given
+        String name = "";
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Brand.validate(name);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("브랜드명은 null이거나 빈 문자열일 수 없습니다.");
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandTest.java
@@ -1,13 +1,12 @@
 package com.loopers.domain.brand;
 
-import com.loopers.domain.stock.Stock;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BrandTest {
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
@@ -7,15 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @Transactional

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.loopers.domain.like;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class LikeServiceIntegrationTest {
+
+    private LikeService likeService;
+    private StubLikeRepository stubLikeRepository;
+
+    @BeforeEach
+    void setUp() {
+        stubLikeRepository = new StubLikeRepository();
+        likeService = new LikeService(stubLikeRepository);
+    }
+
+    @DisplayName("좋아요 등록 요청 시, 처음이면 저장되고 true가 반환된다.")
+    @Test
+    void returnTrue_whenLikeIsSavedFirstTime() {
+        // given
+        Like like = new Like(1L, 100L); // userId=1, productId=100
+
+        // when
+        boolean result = likeService.create(like);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("좋아요 등록 요청 시, 멱등성 보장이 되도록 이미 존재하면 아무 작업 없이 true가 반환된다.")
+    @Test
+    void returnTrue_whenLikeAlreadyExists() {
+        // given
+        Like like = new Like(1L, 100L);
+        stubLikeRepository.save(like);
+
+        // when
+        boolean result = likeService.create(like);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+}
+
+class StubLikeRepository implements LikeRepository {
+    // Map<refUserId, Set<refProductId>>
+    private final Map<Long, Set<Long>> store = new HashMap<>();
+
+    @Override
+    public Like save(Like like) {
+        Long refUserId = like.getRefUserId();
+        Long refProductId = like.getRefProductId();
+
+        store.computeIfAbsent(refUserId, k -> new HashSet<>());
+        store.get(refUserId).add(refProductId);
+        return like;
+    }
+
+    @Override
+    public boolean existsByRefUserIdAndRefProductId(Long refUserId, Long refProductId) {
+        return store.getOrDefault(refUserId, Collections.emptySet()).contains(refProductId);
+    }
+
+    @Override
+    public boolean delete(Long refUserId, Long refProductId) {
+        Set<Long> productSet = store.get(refUserId);
+        if (productSet == null) return false;
+        boolean removed = productSet.remove(refProductId);
+        if (productSet.isEmpty()) {
+            store.remove(refUserId);
+        }
+        return removed;
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeTest.java
@@ -1,0 +1,77 @@
+package com.loopers.domain.like;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LikeTest {
+
+    @DisplayName("참조 User ID가 null일 경우, 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreate_whenRefUserIdIsNull(){
+        // given
+        Long refUserId = null;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Like.validateRefUserId(refUserId);
+        });
+
+        // than
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("참조 사용자 ID는 null일 수 없습니다.");
+    }
+
+    @DisplayName("참조 상품 ID가 null일 경우, 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreate_whenRefProductIdIsNull(){
+        // given
+        Long refProductId = null;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Like.validateRefProductId(refProductId);
+        });
+
+        // than
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("참조 상품 ID는 null일 수 없습니다.");
+    }
+
+    @DisplayName("참조 사용자 ID가 음수일 경우, 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreate_whenReferenceUserIdIsNegative(){
+        // given
+        Long refUserId = -1L;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Like.validateRefUserId(refUserId);
+        });
+
+        // than
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("참조 사용자 ID는 음수일 수 없습니다.");
+    }
+
+    @DisplayName("참조 상품 ID가 음수일 경우, 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreate_whenReferenceProductIdIsNegative(){
+        // given
+        Long refProductId = -1L;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Like.validateRefProductId(refProductId);
+        });
+
+        // than
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("참조 상품 ID는 음수일 수 없습니다.");
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikedProductsTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikedProductsTest.java
@@ -1,0 +1,59 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.like.dto.LikedProductDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LikedProductsTest {
+    @Mock
+    private LikeRepository likeRepository;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @DisplayName("좋아요 한 상품 목록을 조회한다.")
+    @Test
+    void returnLikedProducts_whenUserHasLikes() {
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        LikedProductDto dto = new LikedProductDto(
+                100L,
+                200L,
+                "상품명",
+                BigDecimal.valueOf(10000),
+                BigDecimal.valueOf(9000),
+                "SELLING",
+                true,
+                5L
+        );
+
+        Page<LikedProductDto> page = new PageImpl<>(List.of(dto), pageable, 1);
+
+        when(likeRepository.findLikedProductsByRefUserId(userId, pageable)).thenReturn(page);
+
+        Page<LikedProductDto> result = likeService.getLikedProducts(userId, pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).productName()).isEqualTo("상품명");
+
+        verify(likeRepository).findLikedProductsByRefUserId(userId, pageable);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.loopers.domain.point;
 
-import com.loopers.domain.user.vo.UserId;
 import com.loopers.support.error.CoreException;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -1,11 +1,14 @@
 package com.loopers.domain.product;
 
+import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -114,6 +117,11 @@ class ProductRepositoryStub implements ProductRepository {
 
     @Override
     public Product save(Product product) {
+        return null;
+    }
+
+    @Override
+    public Page<ProductWithLikeCountDto> findProductsWithLikeCount(Long brandId, Pageable pageable) {
         return null;
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -111,4 +111,9 @@ class ProductRepositoryStub implements ProductRepository {
     public boolean existsById(Long id) {
         return store.containsKey(id);
     }
+
+    @Override
+    public Product save(Product product) {
+        return null;
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -1,0 +1,114 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class ProductServiceIntegrationTest {
+    private ProductService productService;
+    private ProductRepositoryStub stubRepository;
+
+    @BeforeEach
+    void setUp() {
+        stubRepository = new ProductRepositoryStub();
+        productService = new ProductService(stubRepository);
+    }
+
+    @DisplayName("상품 ID가 존재할 경우, 상품 상세가 반환된다.")
+    @Test
+    void returnProductDetail_whenIdExists() {
+        // given
+        Long productId = 1L;
+        Product product = Product.from(
+                "상품명",
+                "상품 설명",
+                new BigDecimal("9000"),
+                new BigDecimal("10000"),
+                "ON_SALE",
+                1L
+        );
+        stubRepository.save(product, productId);
+
+        // when
+        Product found = productService.getDetail(productId);
+
+        // then
+        assertThat(found.getName()).isEqualTo("상품명");
+        assertThat(found.getSellingPrice().getValue()).isEqualByComparingTo("10000");
+    }
+
+    @DisplayName("상품 ID가 존재하지 않을 경우, NOT_FOUND 예외가 발생한다.")
+    @Test
+    void throwNotFoundException_whenProductIdNotFound() {
+        // given
+        Long nonExistentId = 999L;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            productService.getDetail(nonExistentId);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND); // ErrorType 확인
+        assertThat(exception.getMessage()).isEqualTo("상품 ID가 존재하지 않습니다."); // 메시지 확인
+    }
+
+    @DisplayName("상품 ID가 존재할 경우 true를 반환한다.")
+    @Test
+    void returnTrue_whenProductExists() {
+        // given
+        Long id = 1L;
+        Product product = Product.from("상품", "설명", new BigDecimal("9000"), new BigDecimal("10000"), "ON_SALE", 1L);
+        stubRepository.save(product, id);
+
+        // when
+        boolean exists = productService.existsById(id);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @DisplayName("상품 ID가 존재하지 않을 경우 false를 반환한다.")
+    @Test
+    void returnFalse_whenProductNotExists() {
+        // given
+        Long id = 100L;
+
+        // when
+        boolean exists = productService.existsById(id);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+}
+
+
+class ProductRepositoryStub implements ProductRepository {
+    private final Map<Long, Product> store = new HashMap<>();
+
+    public void save(Product product, Long id) {
+        store.put(id, product);
+    }
+
+    @Override
+    public Optional<Product> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return store.containsKey(id);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -1,8 +1,5 @@
 package com.loopers.domain.product;
 
-import com.loopers.domain.point.PointRepository;
-import com.loopers.domain.point.PointService;
-import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,13 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductTest.java
@@ -1,0 +1,115 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.product.vo.Money;
+import com.loopers.domain.product.vo.SaleStatus;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProductTest {
+
+    @DisplayName("원가가 할인가보다 작은 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateProduct_whenOriginalPriceIsLessThanSellingPrice() {
+        // given
+        BigDecimal originalPrice = new BigDecimal("40000");
+        BigDecimal sellingPrice = new BigDecimal("50000");
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Product.validateOriginalPriceAndSellingPrice(originalPrice,sellingPrice);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("원가보다 할인가가 높을 수 없습니다.");
+    }
+
+    @DisplayName("상품명이 null이거나 빈 문자열일경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateProduct_whenNameIsNull_orEmpty() {
+        // given
+        BigDecimal originalPrice = new BigDecimal("40000");
+        BigDecimal sellingPrice = new BigDecimal("50000");
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Product.validateOriginalPriceAndSellingPrice(originalPrice,sellingPrice);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("상품명은 null이거나 빈 문자열일 수 없습니다.");
+    }
+
+    @DisplayName("Money의 value가 null인 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateMoney_whenValueIsNull() {
+        // given
+        BigDecimal originalPrice = null;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Money.validate(originalPrice);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("가격은 null일 수 없습니다.");
+    }
+
+    @DisplayName("Money의 value가 음수인 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateMoney_whenValueIsNegative() {
+        // given
+        BigDecimal originalPrice = new BigDecimal("-50000");
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Money.validate(originalPrice);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("가격은 음수일 수 없습니다.");
+    }
+
+    @DisplayName("SaleStatus는 null이거나 빈 문자열일 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateProduct_whenSaleStatusIsNullOrBlank() {
+        // given
+        String saleStatus = "";
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            SaleStatus.validate(saleStatus);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("SaleStatus는 null이거나 빈 문자열일 수 없습니다.");
+    }
+
+    @DisplayName("SaleStatus에 정의된 값이 아닐 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateProduct_whenSaleStatusIsInvalid() {
+        // given
+        String saleStatus = "ON_SALE_";
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            SaleStatus.validate(saleStatus);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("사용 가능한 SaleStatus가 아닙니다.");
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProjectsTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProjectsTest.java
@@ -1,13 +1,5 @@
 package com.loopers.domain.product;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-
-import com.loopers.domain.product.ProductRepository;
-import com.loopers.domain.product.ProductService;
 import com.loopers.domain.product.vo.SaleStatus;
 import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +17,8 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 class ProductsTest {
     @Mock

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProjectsTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProjectsTest.java
@@ -1,0 +1,89 @@
+package com.loopers.domain.product;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.vo.SaleStatus;
+import com.loopers.interfaces.api.product.ProductWithLikeCountDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductsTest {
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductService productService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("브랜드 ID 필터링 적용하여 상품 목록을 조회한다.")
+    @Test
+    void getProducts_shouldReturnPageOfProducts_whenBrandIdIsProvided() {
+        // given
+        Long brandId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        ProductWithLikeCountDto dto1 = new ProductWithLikeCountDto(
+                101L, "상품1", new BigDecimal("10000"), new BigDecimal("9000"),
+                SaleStatus.ON_SALE, brandId, "브랜드1", 5L);
+        ProductWithLikeCountDto dto2 = new ProductWithLikeCountDto(
+                102L, "상품2", new BigDecimal("15000"), new BigDecimal("12000"),
+                SaleStatus.ON_SALE, brandId, "브랜드1", 3L);
+
+        Page<ProductWithLikeCountDto> page = new PageImpl<>(List.of(dto1, dto2), pageable, 2);
+
+        when(productRepository.findProductsWithLikeCount(eq(brandId), eq(pageable))).thenReturn(page);
+
+        // when
+        Page<ProductWithLikeCountDto> result = productService.getProducts(brandId, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getProductName()).isEqualTo("상품1");
+        assertThat(result.getContent().get(0).getLikeCount()).isEqualTo(5L);
+        assertThat(result.getContent().get(1).getProductName()).isEqualTo("상품2");
+    }
+
+    @DisplayName("브랜드 ID 없이 전체 상품을 조회해온다.")
+    @Test
+    void getProducts_shouldReturnPageOfProducts_whenBrandIdIsNull() {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        ProductWithLikeCountDto dto = new ProductWithLikeCountDto(
+                201L, "상품A", new BigDecimal("20000"), new BigDecimal("18000"),
+                SaleStatus.ON_SALE, 2L, "브랜드2", 7L);
+
+        Page<ProductWithLikeCountDto> page = new PageImpl<>(List.of(dto), pageable, 1);
+
+        when(productRepository.findProductsWithLikeCount(eq(null), eq(pageable))).thenReturn(page);
+
+        Page<ProductWithLikeCountDto> result = productService.getProducts(null, pageable);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getBrandName()).isEqualTo("브랜드2");
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/stock/StockTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/stock/StockTest.java
@@ -1,0 +1,60 @@
+package com.loopers.domain.stock;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StockTest {
+
+    @DisplayName("상품 ID가 null일 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateProduct_whenProductIdIsNull() {
+        // given
+        Long refProductId = null;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Stock.validateRefProductId(refProductId);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("상품 ID는 null일 수 없습니다.");
+    }
+
+    @DisplayName("상품 ID가 음수일 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateProduct_whenProductIdIsNegative() {
+        // given
+        Long refProductId = -1L;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Stock.validateRefProductId(refProductId);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("상품 ID는 음수일 수 없습니다.");
+    }
+
+    @DisplayName("재고 수량이 음수일 경우 400 BAD_REQUEST 에러를 반환한다.")
+    @Test
+    void failToCreateProduct_whenStockQuantityIsNegative() {
+        // given
+        int quantity = -1;
+
+        // when
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            Stock.validateQuantity(quantity);
+        });
+
+        // then
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("재고 수량은 음수일 수 없습니다.");
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/like/LikeV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/like/LikeV1ApiE2ETest.java
@@ -1,0 +1,74 @@
+package com.loopers.interfaces.api.like;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.loopers.domain.like.Like;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class LikeV1ApiE2ETest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setup() {
+        // 테스트에 사용할 상품 생성
+        Product product1 = productRepository.save(
+                Product.from("상품1", "설명", BigDecimal.valueOf(10000), BigDecimal.valueOf(12000), "ON_SALE", 1L)
+        );
+        Product product2 = productRepository.save(
+                Product.from("상품2", "설명", BigDecimal.valueOf(15000), BigDecimal.valueOf(20000), "ON_SALE", 1L)
+        );
+
+        // 좋아요 생성
+        likeRepository.save(Like.from(1L, product1.getId()));
+        likeRepository.save(Like.from(1L, product2.getId()));
+    }
+
+    @Test
+    void shouldReturnLikedProductList_whenLikedProductsExist() throws Exception {
+        // given
+        Long refUserId = 1L;
+
+        // when & then
+        mockMvc.perform(get("/api/v1/like/products")
+                        .header("X-USER-ID", refUserId.toString())
+                        .param("refuserId", "1")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sort", "createdAt,DESC"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].productName").exists())
+                .andExpect(jsonPath("$.content[0].productId").exists())
+                .andExpect(jsonPath("$.content[0].liked").value(true))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
## 📌 Summary
- [ 주제 ] Domain Modeling & Development
- [ 구현목록 ]
1. 상품 - 목록조회 / 상세정보 조회
2. 브랜드 - 상세정보 조회
3. 좋아요 - 등록 및 취소 / 좋아요한 상품 목록 조회
4. 주문 - 여러상품 한번에 주문 요청 / 목록 조회 / 상제 정보 조회


## 💬 Review Points
- [ 제 도메인 엉망진창인 것 같아요😭 도메인 설계할 때 고려하면 좋을 점 알려주세요 ] 
체크리스트에 있는 목록으로 진행하려니 막히는 구간이 많았는데, 이번 주차에 고민을 해봤는데 결국 도메인 설계가 굉장히,,중요하다는 걸 알았습니다. 도메인 설계를 Entity로 필드로만 생각했었는데, 그게 아닌걸 알았습니다. 도메인 설계할때 어떤 점을 생각하며 좋을지 궁굼합니다.

- [ QueryDsl 사용하여 조인 쿼리와 응답 Dto 위치 ]
목록을 조회할때 QueryDsl을 사용하여 조회를 해왔습니다. 계층간의 책임과 도메인간 책임을 지키고자 고민이 많이 되더라구요. 제가 사용한 QueryDsl 쿼리의 응답 Dto 위치가 적절한지, DDD관점에서 책임이나 구조가 적절한지 봐주시면 감사하겠습니다!

- [ 도메인 설계시 참조ID 값은 Entity vs LongId ]
도메인 설계할 때 참조하는 ID 값은 Long 타입으로 설계를 하고 구현을 진행했습니다. Entity로 넣어두면 도메인에 다른도메인이 얹어 진다는 생각으로 그렇게 진행을 했는데, 두개의 도메인을 조회해야 할때, 간단한 조회인데도 QueryDsl을 써야하나 생각으로 도메인 설계가 잘못되었나 생각이 들더라구요. 보통 Entity를 사용하는게 DDD관점이나 유지보수 관점이나 유용한 방향일까요?


## ✅ Checklist

### 🎁 Product 도메인

- [x]  상품 정보 객체는 브랜드 정보, 좋아요 수를 포함한다.
- [x]  상품의 정렬 조건(`latest`, `price_asc`, `likes_desc`) 을 고려한 조회 기능을 설계했다
- [x]  상품은 재고를 가지고 있고, 주문 시 차감할 수 있어야 한다
- [x]  재고는 감소만 가능하며 음수 방지는 도메인 레벨에서 처리된다

### 👍 Like 도메인

- [x]  좋아요는 유저와 상품 간의 관계로 별도 도메인으로 분리했다
- [x]  중복 좋아요 방지를 위한 멱등성 처리가 구현되었다
- [x]  상품의 좋아요 수는 상품 상세/목록 조회에서 함께 제공된다
- [x]  단위 테스트에서 좋아요 등록/취소/중복 방지 흐름을 검증했다

### 🛒 Order 도메인

- [x]  주문은 여러 상품을 포함할 수 있으며, 각 상품의 수량을 명시한다
- [x]  주문 시 상품의 재고 차감, 유저 포인트 차감 등을 수행한다
- [x]  재고 부족, 포인트 부족 등 예외 흐름을 고려해 설계되었다
- [x]  단위 테스트에서 정상 주문 / 예외 주문 흐름을 모두 검증했다

### 🧩 도메인 서비스

- [x]  도메인 간 협력 로직은 Domain Service에 위치시켰다
- [ ]  상품 상세 조회 시 Product + Brand 정보 조합은 도메인 서비스에서 처리했다
- [x]  복합 유스케이스는 Application Layer에 존재하고, 도메인 로직은 위임되었다
- [x]  도메인 서비스는 상태 없이, 도메인 객체의 협력 중심으로 설계되었다

### **🧱 소프트웨어 아키텍처 & 설계**

- [x]  전체 프로젝트의 구성은 아래 아키텍처를 기반으로 구성되었다
    - Application → **Domain** ← Infrastructure
- [x]  Application Layer는 도메인 객체를 조합해 흐름을 orchestration 했다
- [x]  핵심 비즈니스 로직은 Entity, VO, Domain Service 에 위치한다
- [x]  Repository Interface는 Domain Layer 에 정의되고, 구현체는 Infra에 위치한다
- [x]  패키지는 계층 + 도메인 기준으로 구성되었다 (`/domain/order`, `/application/like` 등)
- [ ]  테스트는 외부 의존성을 분리하고, Fake/Stub 등을 사용해 단위 테스트가 가능하게 구성되었다
